### PR TITLE
Add initial TimesFM PPO pipeline skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+ALPHA_VANTAGE_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -1,48 +1,60 @@
-# FinFM Data Preparation
+# FinFM Pipeline
 
-This repository contains utilities for downloading and preparing
-historical price data for use with time series models like
-`timesfm`.
+This repository provides a minimal starting point for fine-tuning the
+[TimesFM](https://github.com/google-research/timesfm) model with PPO for
+stock price forecasting.  It contains utilities for data ingestion,
+pre‑processing, training and a small FastAPI service for inference.
 
-The `data_prep.py` script lists a set of major U.S. stocks and ETFs
-and downloads their historical prices using the `yfinance` package.
-This data can be used for model training, fine-tuning, and
-forecasting.
-
-## Requirements
-
-- Python 3.8+
-- [`yfinance`](https://pypi.org/project/yfinance/)
-- `pandas`
-
-Install requirements with:
-
-```bash
-pip install yfinance pandas
+```
+├─ configs/                # Hydra style YAML configs (placeholders)
+├─ data/                   # Raw and processed data folders
+├─ src/
+│   ├─ cli.py              # Entry points: download, preprocess, train, predict
+│   ├─ data/               # Data fetcher and preprocessing modules
+│   ├─ model/              # TimesFM wrapper and reward function
+│   ├─ train/              # PPO trainer and evaluation utilities
+│   └─ serving/            # FastAPI app and predictor helper
 ```
 
-## Usage
+The code focuses on structure rather than full functionality.  Modules
+can be extended with real training logic, MLflow tracking and proper
+configurations.
 
-List major tickers:
+## Quick start
 
-```bash
-python data_prep.py --list-tickers
-```
-
-Download historical data to `data.csv`:
+Install the required packages:
 
 ```bash
-python data_prep.py --start 2010-01-01 --end 2023-01-01 \
-  --interval 1d --output data.csv
+pip install yfinance pandas transformers trl fastapi typer
 ```
 
-Update existing data file with the latest prices:
+Download historical data:
 
 ```bash
-python data_prep.py --update data.csv
+python -m src.cli download-data \
+  --symbols AAPL MSFT \
+  --start 2015-01-01 --end 2023-01-01 \
+  --output data/raw/prices.csv
 ```
 
-The CSV file contains a column for the ticker symbol, the date, and
-Open/High/Low/Close/Adj Close/Volume columns returned by `yfinance`.
-Use this file to train or fine-tune your `timesfm` models and to fetch
-new data for future predictions.
+Preprocess the data:
+
+```bash
+python -m src.cli preprocess-data --input-path data/raw/prices.csv
+```
+
+Run a dummy training loop (placeholder):
+
+```bash
+python -m src.cli train
+```
+
+Start the prediction service:
+
+```bash
+uvicorn src.serving.app:app --reload
+```
+
+This repository serves as a template that matches the layout described
+in the blueprint.  Additional components like full PPO training,
+MLflow integration and Docker files can be added as needed.

--- a/configs/data.yaml
+++ b/configs/data.yaml
@@ -1,0 +1,6 @@
+# Data configuration (placeholder)
+symbols:
+  - AAPL
+  - MSFT
+start: 2015-01-01
+end: 2023-01-01

--- a/configs/infer.yaml
+++ b/configs/infer.yaml
@@ -1,0 +1,3 @@
+# Inference configuration (placeholder)
+horizon: 1
+features: [open, high, low, close, volume]

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,0 +1,4 @@
+# Training configuration (placeholder)
+learning_rate: 1e-5
+batch_size: 8
+epochs: 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . /app
+RUN pip install --no-cache-dir yfinance pandas transformers trl fastapi typer uvicorn
+
+CMD ["uvicorn", "src.serving.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "finfm"
+version = "0.1.0"
+description = "TimesFM PPO fine-tuning pipeline"
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+yfinance = "*"
+pandas = "*"
+transformers = "*"
+trl = "*"
+fastapi = "*"
+typer = "*"
+uvicorn = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t finfm .

--- a/scripts/run_train.sh
+++ b/scripts/run_train.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m src.cli train "$@"

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,48 @@
+"""Command line interface for FinFM pipeline."""
+from __future__ import annotations
+
+import typer
+
+from src.data.fetcher import download
+from src.data.preprocess import preprocess
+from src.train.ppo_trainer import train as train_model
+from src.serving.predictor import predict
+
+cli = typer.Typer()
+
+@cli.command()
+def download_data(
+    symbols: str = typer.Option(..., help="Space separated tickers"),
+    start: str = typer.Option(..., help="Start date YYYY-MM-DD"),
+    end: str = typer.Option(..., help="End date YYYY-MM-DD"),
+    interval: str = typer.Option("1d", help="Data interval"),
+    output: str = typer.Option("data/raw/data.csv", help="Output CSV path"),
+):
+    tickers = symbols.split()
+    df = download(tickers, start, end, interval)
+    df.to_csv(output, index=False)
+    typer.echo(f"Saved {len(df)} rows to {output}")
+
+@cli.command()
+def preprocess_data(
+    input_path: str = typer.Option("data/raw/data.csv"),
+    output_dir: str = typer.Option("data/processed"),
+):
+    preprocess(input_path, output_dir)
+
+@cli.command()
+def train(config: str = typer.Option("configs/train.yaml")):
+    train_model(config)
+
+@cli.command()
+def predict_cli(
+    symbol: str,
+    context: str,
+    horizon: int = 1,
+):
+    ctx = [float(x) for x in context.split(',')]
+    result = predict(symbol, ctx, horizon)
+    typer.echo(str(result))
+
+if __name__ == "__main__":
+    cli()

--- a/src/data/fetcher.py
+++ b/src/data/fetcher.py
@@ -1,0 +1,26 @@
+"""Data fetching utilities using yfinance."""
+from __future__ import annotations
+
+from typing import Iterable
+import pandas as pd
+import yfinance as yf
+
+
+def download(tickers: Iterable[str], start: str, end: str, interval: str = "1d") -> pd.DataFrame:
+    """Download historical data for the given tickers."""
+    data = yf.download(
+        tickers=list(tickers),
+        start=start,
+        end=end,
+        interval=interval,
+        group_by="ticker",
+        auto_adjust=False,
+        threads=True,
+    )
+    frames = []
+    for ticker in tickers:
+        df = data[ticker].copy()
+        df["Ticker"] = ticker
+        df.reset_index(inplace=True)
+        frames.append(df)
+    return pd.concat(frames, ignore_index=True)

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -1,0 +1,15 @@
+"""Preprocessing utilities for TimesFM."""
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+
+
+def preprocess(input_path: str, output_dir: str) -> None:
+    """Simple example preprocessing that saves numpy arrays."""
+    df = pd.read_csv(input_path, parse_dates=["Date"])
+    df.sort_values(["Ticker", "Date"], inplace=True)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    for ticker, group in df.groupby("Ticker"):
+        out_file = Path(output_dir) / f"{ticker}.csv"
+        group.to_csv(out_file, index=False)

--- a/src/model/reward.py
+++ b/src/model/reward.py
@@ -1,0 +1,14 @@
+"""Reward function for PPO fine-tuning."""
+from __future__ import annotations
+
+import torch
+
+
+def mape_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Mean absolute percentage error."""
+    return (pred - target).abs() / target.abs().clamp(min=1e-5)
+
+
+def reward_fn(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Simple negative MAPE reward."""
+    return -mape_loss(pred, target).mean()

--- a/src/model/timesfm_wrapper.py
+++ b/src/model/timesfm_wrapper.py
@@ -1,0 +1,12 @@
+"""Wrapper around the Hugging Face TimesFM model."""
+from __future__ import annotations
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+MODEL_NAME = "google/timesfm-1.0-200m"
+
+def load_model(model_name: str = MODEL_NAME):
+    """Load the pretrained TimesFM model and tokenizer."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    return model, tokenizer

--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -1,0 +1,21 @@
+"""FastAPI service for TimesFM predictions."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from src.serving.predictor import predict
+
+app = FastAPI(title="FinFM TimesFM Service")
+
+
+class PredictRequest(BaseModel):
+    symbol: str
+    context: list[float]
+    horizon: int = 1
+
+
+@app.post("/predict")
+async def predict_endpoint(req: PredictRequest):
+    result = predict(req.symbol, req.context, req.horizon)
+    return {"predictions": result}

--- a/src/serving/predictor.py
+++ b/src/serving/predictor.py
@@ -1,0 +1,26 @@
+"""Model prediction utilities."""
+from __future__ import annotations
+
+from typing import List
+
+import torch
+
+from src.model.timesfm_wrapper import load_model
+
+
+_model = None
+_tokenizer = None
+
+
+def get_model():
+    global _model, _tokenizer
+    if _model is None:
+        _model, _tokenizer = load_model()
+        _model.eval()
+    return _model, _tokenizer
+
+
+def predict(symbol: str, context: List[float], horizon: int = 1) -> List[float]:
+    model, tokenizer = get_model()
+    # Dummy implementation that returns zeros
+    return [0.0 for _ in range(horizon)]

--- a/src/train/eval.py
+++ b/src/train/eval.py
@@ -1,0 +1,15 @@
+"""Evaluation utilities for TimesFM models."""
+from __future__ import annotations
+
+import torch
+
+
+def evaluate(model, dataloader):
+    """Placeholder evaluation loop."""
+    model.eval()
+    results = []
+    with torch.no_grad():
+        for batch in dataloader:
+            outputs = model(**batch)
+            results.append(outputs.logits)
+    return results

--- a/src/train/ppo_trainer.py
+++ b/src/train/ppo_trainer.py
@@ -1,0 +1,30 @@
+"""PPO training loop using Hugging Face TRL."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from transformers import AutoTokenizer
+from trl import PPOTrainer, PPOConfig
+
+from src.model.timesfm_wrapper import load_model
+from src.model.reward import reward_fn
+
+
+def train(config_path: str) -> None:
+    """Train the TimesFM model with PPO."""
+    # Placeholder example loading config
+    config = PPOConfig()
+    model, tokenizer = load_model()
+    trainer = PPOTrainer(model, ref_model=None, tokenizer=tokenizer, config=config)
+
+    # Example training loop using dummy data
+    dummy_input = torch.randint(0, tokenizer.vocab_size, (1, 16))
+    dummy_label = torch.randn(1, 1)
+    rewards = reward_fn(torch.randn(1, 1), dummy_label)
+    trainer.step(dummy_input, dummy_input, rewards)
+
+    Path("mlruns").mkdir(exist_ok=True)
+    # Save model checkpoint (placeholder)
+    trainer.save_pretrained("mlruns/latest")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- implement skeletal folder layout for TimesFM fine-tuning
- add CLI entrypoints and data utilities
- create model wrapper, reward function and minimal PPO trainer
- provide FastAPI service and Dockerfile
- update README with quick start instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652859efb8832e801efa29370469f7