### PR TITLE
Implement PPO training wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Preprocess the data:
 python -m src.cli preprocess-data --input-path data/raw/prices.csv
 ```
 
-Run a dummy training loop (placeholder):
+Run PPO fine-tuning for a single ticker:
 
 ```bash
-python -m src.cli train
+python -m src.train.run_train ticker=AAPL gitsha=dev
 ```
 
 Start the prediction service:

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,4 +1,12 @@
-# Training configuration (placeholder)
-learning_rate: 1e-5
-batch_size: 8
-epochs: 1
+defaults:
+  - _self_
+
+data_path: "data/processed/${gitsha}/${ticker}/train.npz"
+val_path: "data/processed/${gitsha}/${ticker}/val.npz"
+base_ckpt: "google/timesfm-1.0-200m-pytorch"
+lora_r: 8
+ppo:
+  rollout_batch_size: 64
+  epochs: 3
+  target_kl: 0.2
+  clip_range: 0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ trl = "*"
 fastapi = "*"
 typer = "*"
 uvicorn = "*"
+mlflow = "*"
+hydra-core = "*"
+peft = "*"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/cli.py
+++ b/src/cli.py
@@ -5,7 +5,7 @@ import typer
 
 from src.data.fetcher import download
 from src.data.preprocess import preprocess
-from src.train.ppo_trainer import train as train_model
+from src.train import run_train
 from src.serving.predictor import predict
 
 cli = typer.Typer()
@@ -31,8 +31,9 @@ def preprocess_data(
     preprocess(input_path, output_dir)
 
 @cli.command()
-def train(config: str = typer.Option("configs/train.yaml")):
-    train_model(config)
+def train(ticker: str):
+    """Run PPO fine-tuning for *ticker* using Hydra configs."""
+    run_train.main([f"ticker={ticker}"])
 
 @cli.command()
 def predict_cli(

--- a/src/model/timesfm_wrapper.py
+++ b/src/model/timesfm_wrapper.py
@@ -1,12 +1,54 @@
-"""Wrapper around the Hugging Face TimesFM model."""
+"""TimesFM model wrapper with optional LoRA adapters and value head."""
 from __future__ import annotations
 
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from typing import Optional
 
-MODEL_NAME = "google/timesfm-1.0-200m"
+import torch
+from torch import nn
+from transformers import AutoModel
 
-def load_model(model_name: str = MODEL_NAME):
-    """Load the pretrained TimesFM model and tokenizer."""
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name)
-    return model, tokenizer
+
+__all__ = ["TimesFMForPPO"]
+
+
+def _maybe_add_lora(model: nn.Module, r: Optional[int]) -> nn.Module:
+    """Add LoRA adapters to *model* if ``r`` is specified."""
+    if not r:
+        return model
+    try:
+        from peft import LoraConfig, get_peft_model
+    except Exception:  # peft may not be installed
+        return model
+
+    config = LoraConfig(r=r, lora_alpha=r, target_modules=None)
+    return get_peft_model(model, config)
+
+
+class TimesFMForPPO(nn.Module):
+    """Tiny wrapper around ``google/timesfm`` for PPO fine-tuning."""
+
+    def __init__(self, base_ckpt: str, lora_r: Optional[int] = None, num_stocks: int | None = None, emb_dim: int = 16) -> None:
+        super().__init__()
+        self.timesfm = AutoModel.from_pretrained(base_ckpt)
+        hidden_size = self.timesfm.config.hidden_size
+        self.timesfm = _maybe_add_lora(self.timesfm, lora_r)
+
+        if num_stocks:
+            self.id_emb = nn.Embedding(num_stocks, emb_dim)
+            hidden_size += emb_dim
+        else:
+            self.id_emb = None
+
+        self.value_head = nn.Linear(hidden_size, 1)
+        self.policy_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, x: torch.Tensor, stock_id: Optional[torch.LongTensor] = None):
+        """Return price delta prediction and value estimate."""
+        if self.id_emb is not None and stock_id is not None:
+            emb = self.id_emb(stock_id).unsqueeze(1).expand(-1, x.size(1), -1)
+            x = torch.cat([x, emb], dim=-1)
+
+        features = self.timesfm(inputs_embeds=x).last_hidden_state
+        value = self.value_head(features)
+        pred = self.policy_head(features)
+        return pred, value

--- a/src/train/reward.py
+++ b/src/train/reward.py
@@ -1,0 +1,16 @@
+"""Reward utilities for PPO training."""
+from __future__ import annotations
+
+import torch
+
+
+def abs_return_error(pred_ret: torch.Tensor, true_ret: torch.Tensor) -> torch.Tensor:
+    """Absolute return error."""
+    return (pred_ret - true_ret).abs()
+
+
+def reward_fn(pred_ret: torch.Tensor, true_ret: torch.Tensor) -> torch.Tensor:
+    """Scale negative absolute return error to ``[-2, 0]`` for PPO."""
+    error = abs_return_error(pred_ret, true_ret)
+    reward = -error
+    return reward.clamp(min=-2.0, max=0.0)

--- a/src/train/run_train.py
+++ b/src/train/run_train.py
@@ -1,0 +1,31 @@
+"""Command line entry point for PPO training."""
+from __future__ import annotations
+
+import mlflow
+from omegaconf import DictConfig, OmegaConf
+import hydra
+
+from src.train.ppo_trainer import TrainerConfig, train_ppo
+
+
+@hydra.main(config_path="../../configs", config_name="train.yaml", version_base=None)
+def main(cfg: DictConfig) -> None:
+    ticker = cfg.get("ticker")
+    gitsha = cfg.get("gitsha", "dev")
+    trainer_cfg = TrainerConfig(
+        base_ckpt=cfg.base_ckpt,
+        lora_r=cfg.lora_r if cfg.lora_r > 0 else None,
+        data_path=cfg.data_path,
+        val_path=cfg.val_path,
+        ppo=OmegaConf.to_container(cfg.ppo, resolve=True),
+    )
+
+    with mlflow.start_run(run_name=f"PPO_{ticker}_{gitsha}"):
+        mlflow.log_params(OmegaConf.to_container(cfg, resolve=True))
+        model = train_ppo(trainer_cfg)
+        mlflow.pytorch.log_model(model, "model")
+        mlflow.set_tag("ticker", ticker)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend TimesFM model wrapper with LoRA, value and policy heads
- add reward and training helpers for PPO
- provide Hydra-driven training entry point
- update config and README example
- include new dependencies in `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652f72d914832eb2b11982363d790c