### PR TITLE
Implement TimesFM PPO training skeleton

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -1,4 +1,13 @@
-# Training configuration (placeholder)
-learning_rate: 1e-5
-batch_size: 8
-epochs: 1
+defaults:
+  - _self_
+
+data_path: "data/processed/${gitsha}/${ticker}/train.npz"
+val_path: "data/processed/${gitsha}/${ticker}/val.npz"
+base_ckpt: "google/timesfm-1.0-200m-pytorch"
+lora_r: 8
+ppo:
+  rollout_batch_size: 64
+  epochs: 3
+  target_kl: 0.2
+  clip_range: 0.2
+

--- a/src/model/timesfm_wrapper.py
+++ b/src/model/timesfm_wrapper.py
@@ -1,12 +1,52 @@
-"""Wrapper around the Hugging Face TimesFM model."""
+"""TimesFM wrapper with value and policy heads.
+
+This module provides :class:`TimesFMForPPO`, a light wrapper around the
+Hugging Face ``google/timesfm`` checkpoints.  The wrapper exposes a
+``forward`` method that returns both the predicted price delta and a
+value estimate so that it can be optimised with PPO.
+"""
 from __future__ import annotations
 
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from dataclasses import dataclass
+from typing import Optional
 
-MODEL_NAME = "google/timesfm-1.0-200m"
+import torch
+from torch import nn
+from transformers import AutoModel
 
-def load_model(model_name: str = MODEL_NAME):
-    """Load the pretrained TimesFM model and tokenizer."""
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name)
-    return model, tokenizer
+try:
+    from peft import LoraConfig, get_peft_model
+except Exception:  # pragma: no cover - optional dependency
+    LoraConfig = None
+    def get_peft_model(model, config):  # type: ignore
+        return model
+
+
+@dataclass
+class TimesFMConfig:
+    """Configuration for :class:`TimesFMForPPO`."""
+
+    base_ckpt: str = "google/timesfm-1.0-200m-pytorch"
+    lora_r: Optional[int] = None
+
+
+class TimesFMForPPO(nn.Module):
+    """Tiny wrapper adding LoRA, value and policy heads."""
+
+    def __init__(self, cfg: TimesFMConfig):
+        super().__init__()
+        self.timesfm = AutoModel.from_pretrained(cfg.base_ckpt)
+        hidden = self.timesfm.config.hidden_size
+        if cfg.lora_r and LoraConfig is not None:
+            lora_cfg = LoraConfig(r=cfg.lora_r, target_modules="all")
+            self.timesfm = get_peft_model(self.timesfm, lora_cfg)
+        self.value_head = nn.Linear(hidden, 1)
+        self.policy_head = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor, **kwargs):
+        """Return predicted delta and value estimate."""
+        out = self.timesfm(x, **kwargs)
+        h = out.last_hidden_state[:, -1]
+        pred = self.policy_head(h)
+        value = self.value_head(h)
+        return pred, value

--- a/src/train/reward.py
+++ b/src/train/reward.py
@@ -1,0 +1,13 @@
+"""Reward utilities for PPO training."""
+from __future__ import annotations
+
+import torch
+
+
+def reward_fn(pred_close: torch.Tensor, next_close: torch.Tensor, prev_close: torch.Tensor) -> torch.Tensor:
+    """Return negative absolute return error scaled to [-2, 0]."""
+    pred_ret = (pred_close - prev_close) / prev_close
+    true_ret = (next_close - prev_close) / prev_close
+    err = (pred_ret - true_ret).abs()
+    reward = -err.clamp(0, 2)
+    return reward

--- a/src/train/run_train.py
+++ b/src/train/run_train.py
@@ -1,0 +1,25 @@
+"""CLI entry-point to train TimesFM with PPO."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlflow
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+
+from .ppo_trainer import TimesFMPPOTrainer
+
+
+def main(config: str = "configs/train.yaml", **overrides) -> None:
+    with initialize(config_path="configs", version_base=None):
+        cfg = compose(config_name=Path(config).name, overrides=overrides)
+    mlflow.autolog()
+    with mlflow.start_run(run_name=f"PPO_{cfg.get('ticker', 'UNK')}"):
+        mlflow.log_params(OmegaConf.to_container(cfg))
+        trainer = TimesFMPPOTrainer(cfg)
+        trainer.train()
+        mlflow.pytorch.log_model(trainer.model.timesfm, "model")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- overhaul TimesFM wrapper to expose value and policy heads
- implement reward and trainer utilities for PPO
- add Hydra-driven train CLI entrypoint
- update training configuration to match new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686531ab859c832e961500c1d5ae6fb8