### PR TITLE
Implement inference layer

### DIFF
--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -1,21 +1,38 @@
-"""FastAPI service for TimesFM predictions."""
+"""FastAPI service exposing TimesFM predictions."""
 from __future__ import annotations
 
+import os
 from fastapi import FastAPI
 from pydantic import BaseModel
+import pandas as pd
 
-from src.serving.predictor import predict
-
-app = FastAPI(title="FinFM TimesFM Service")
+from src.serving.predictor import Predictor, fetch_context
 
 
-class PredictRequest(BaseModel):
-    symbol: str
-    context: list[float]
-    horizon: int = 1
+MLFLOW_URI = os.getenv("MLFLOW_URI", "http://mlflow.internal:5000")
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def load() -> None:  # pragma: no cover - simple side effect
+    global predictor
+    predictor = Predictor(MLFLOW_URI, ticker=os.getenv("TICKER", "AAPL"))
+
+
+class Input(BaseModel):
+    context: list[list[float]] | None = None
 
 
 @app.post("/predict")
-async def predict_endpoint(req: PredictRequest):
-    result = predict(req.symbol, req.context, req.horizon)
-    return {"predictions": result}
+def predict(inp: Input | None = None):
+    if inp and inp.context:
+        df_ctx = pd.DataFrame(inp.context, columns=predictor.series)
+    else:
+        df_ctx = fetch_context(predictor.series, ctx=predictor.ctx_len)
+    price = predictor.predict_next(df_ctx)
+    return {
+        "ticker": predictor.meta["target_ticker"],
+        "predicted_price": price,
+    }
+

--- a/src/serving/batch.py
+++ b/src/serving/batch.py
@@ -1,0 +1,34 @@
+"""Batch prediction script for cron jobs."""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+import os
+
+import click
+import pandas as pd
+
+from src.serving.predictor import Predictor, fetch_context
+
+
+MLFLOW_URI = os.getenv("MLFLOW_URI", "http://mlflow.internal:5000")
+
+
+@click.command()
+@click.option("--ticker", required=True)
+@click.option("--horizon", default=1)
+def run_batch(ticker: str, horizon: int) -> None:
+    """Generate a prediction and save it to ``data/predictions``."""
+
+    pred = Predictor(MLFLOW_URI, ticker)
+    ctx = fetch_context(pred.series, ctx=pred.ctx_len)
+    price = pred.predict_next(ctx)
+
+    out_path = Path("data/predictions") / f"{date.today()}_{ticker}.csv"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({"pred_price": [price]}, index=[pd.Timestamp.today()]).to_csv(out_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry point
+    run_batch()
+

--- a/src/serving/predictor.py
+++ b/src/serving/predictor.py
@@ -1,26 +1,91 @@
-"""Model prediction utilities."""
+"""Prediction utilities for TimesFM models."""
 from __future__ import annotations
 
-from typing import List
+import json
 
+import joblib
+import mlflow.pyfunc
+import pandas as pd
 import torch
 
-from src.model.timesfm_wrapper import load_model
+from src.data.fetcher import fetch_prices
+from src.data.preprocess import repair_calendar
 
 
-_model = None
-_tokenizer = None
+def fetch_context(
+    symbols: list[str],
+    end: str | None = None,
+    ctx: int = 60,
+    vendor: str = "yfinance",
+) -> pd.DataFrame:
+    """Return a `(ctx, len(symbols) * features)` DataFrame.
+
+    The index is aligned on daily UTC midnight with any gaps forward filled so
+    that the returned frame always has exactly ``ctx`` rows.
+    """
+
+    if end is None:
+        end_dt = pd.Timestamp.utcnow().floor("D") - pd.Timedelta(days=1)
+    else:
+        end_dt = pd.Timestamp(end).tz_localize("UTC").floor("D")
+
+    start_dt = end_dt - pd.Timedelta(days=ctx * 3)
+    df = fetch_prices(
+        symbols=symbols,
+        start=str(start_dt.date()),
+        end=str(end_dt.date()),
+        vendor=vendor,
+        interval="1d",
+    )
+    df = repair_calendar(df)
+    df = (
+        df.reset_index()
+        .pivot(index="date", columns="symbol")
+        .ffill()
+        .tail(ctx)
+    )
+    df.columns = [f"{sym}_{feat}" for feat, sym in df.columns]
+    return df
 
 
-def get_model():
-    global _model, _tokenizer
-    if _model is None:
-        _model, _tokenizer = load_model()
-        _model.eval()
-    return _model, _tokenizer
+def merge_lora(model):
+    """Merge attached LoRA weights into ``model`` if present."""
+
+    try:  # optional dependency
+        from peft import PeftModel
+    except Exception:  # pragma: no cover - peft may be missing
+        return model
+
+    if isinstance(model, PeftModel):
+        model = model.merge_and_unload()
+    return model
 
 
-def predict(symbol: str, context: List[float], horizon: int = 1) -> List[float]:
-    model, tokenizer = get_model()
-    # Dummy implementation that returns zeros
-    return [0.0 for _ in range(horizon)]
+class Predictor:
+    """Thin wrapper around TimesFM checkpoints for inference."""
+
+    def __init__(self, mlflow_uri: str, ticker: str):
+        self.model, self.meta = self._load_model(mlflow_uri, ticker)
+        self.scaler = joblib.load(self.meta["scaler_path"])
+        self.ctx_len = self.meta["ctx_len"]
+        self.series = self.meta["series_list"]
+
+    def _load_model(self, uri: str, ticker: str):
+        m = mlflow.pyfunc.load_model(f"{uri}/TimesFM-PPO/{ticker}/Staging")
+        if "lora" in m.metadata.tags:
+            merge_lora(m._model)
+        meta = json.load(open("meta.json"))
+        return m._model.eval(), meta
+
+    def predict_next(self, df_ctx: pd.DataFrame) -> float:
+        X = self.scaler.transform(df_ctx[self.series].values).astype("float32")
+        tensor = torch.tensor(X).unsqueeze(0)
+        with torch.no_grad():
+            out = self.model(tensor).squeeze(0)
+        return self._postprocess(out, df_ctx)
+
+    def _postprocess(self, y_pred: torch.Tensor, df_ctx: pd.DataFrame) -> float:
+        last_price = df_ctx[f"{self.meta['target_ticker']}_close"].iloc[-1]
+        pred_price = last_price * (1 + y_pred.item())
+        return float(pred_price)
+

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import joblib
+import numpy as np
+import pandas as pd
+import torch
+from fastapi.testclient import TestClient
+from sklearn.preprocessing import StandardScaler
+
+from src.serving import app as serving_app
+from src.serving.predictor import Predictor
+
+
+def _dummy_predictor(tmp_path) -> Predictor:
+    scaler = StandardScaler()
+    scaler.fit(np.array([[0.0, 0.0], [1.0, 1.0]]))
+    scaler_path = tmp_path / "scaler.pkl"
+    joblib.dump(scaler, scaler_path)
+
+    class DummyModel(torch.nn.Module):
+        def forward(self, x):  # type: ignore
+            return torch.tensor([[0.1]], dtype=torch.float32)
+
+    class DummyPredictor(Predictor):
+        def _load_model(self, uri: str, ticker: str):
+            meta = {
+                "scaler_path": str(scaler_path),
+                "ctx_len": 2,
+                "series_list": ["a", "b"],
+                "target_ticker": "a",
+            }
+            return DummyModel(), meta
+
+    return DummyPredictor("uri", "TST")
+
+
+def test_predict_next_returns_float(tmp_path):
+    pred = _dummy_predictor(tmp_path)
+    df = pd.DataFrame([[1.0, 2.0], [1.0, 2.0]], columns=pred.series)
+    out = pred.predict_next(df)
+    assert isinstance(out, float)
+    assert not np.isnan(out)
+
+
+def test_fastapi_predict(monkeypatch, tmp_path):
+    pred = _dummy_predictor(tmp_path)
+
+    def _load():
+        serving_app.predictor = pred
+
+    monkeypatch.setattr(serving_app, "load", _load)
+    serving_app.load()
+
+    client = TestClient(serving_app.app)
+    resp = client.post("/predict", json={"context": [[1.0, 2.0], [1.0, 2.0]]})
+    assert resp.status_code == 200
+    assert "predicted_price" in resp.json()
+


### PR DESCRIPTION
## Summary
- add TimesFM prediction utility functions
- implement FastAPI service and batch script
- provide predictor tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_6865350b1c5c832eb6ae83fb46aff16d