### PR TITLE
Add backtest blueprint modules

### DIFF
--- a/configs/backtest.yaml
+++ b/configs/backtest.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - _self_
+
+ticker: "AAPL"
+vendor: "yfinance"
+start: "2018-01-01"
+end: "2020-01-01"
+train_days: 1500
+test_days: 250
+strategy:
+  _target_: src.backtest.strategy.ThresholdLongShort
+  long: 0.002
+  short: -0.002
+mlflow_uri: "http://mlflow.internal:5000"

--- a/src/backtest/cli.py
+++ b/src/backtest/cli.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hydra
+from omegaconf import DictConfig
+
+from src.serving.predictor import Predictor
+from .loader import get_walk_forward_slices
+from .strategy import BaseStrategy
+from .engine import BacktestEngine
+from .metrics import compute_all_metrics
+from .report import log_to_mlflow
+
+
+@hydra.main(config_path="../../configs", config_name="backtest.yaml", version_base=None)
+def run(cfg: DictConfig) -> None:
+    predictor = Predictor(cfg.mlflow_uri, cfg.ticker)
+    slices = get_walk_forward_slices(
+        predictor.meta,
+        cfg.start,
+        cfg.end,
+        cfg.train_days,
+        cfg.test_days,
+    )
+    strat: BaseStrategy = hydra.utils.instantiate(cfg.strategy)
+    engine = BacktestEngine(predictor, strat)
+    df_res = engine.walk_forward(slices)
+    metrics = compute_all_metrics(df_res)
+    log_to_mlflow(metrics, df_res, cfg)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from src.serving.predictor import Predictor
+from .strategy import BaseStrategy
+
+
+class BacktestEngine:
+    def __init__(self, predictor: Predictor, strat: BaseStrategy):
+        self.pred = predictor
+        self.strat = strat
+
+    def run_slice(self, ctx_df: pd.DataFrame, true_ret: pd.Series):
+        est_ret = self.pred.predict_next(ctx_df)
+        signal = self.strat.generate(est_ret)
+        pl = signal * true_ret.iloc[-1]
+        return est_ret, signal, pl
+
+    def walk_forward(self, slices):
+        results = []
+        for ctx_df, true_ret in slices:
+            results.append(self.run_slice(ctx_df, true_ret))
+        return pd.DataFrame(results, columns=["est_ret", "signal", "pl"])

--- a/src/backtest/loader.py
+++ b/src/backtest/loader.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
+from typing import Iterable
+
+from src.data.fetcher import fetch_prices
+from src.data.preprocess import repair_calendar
+
+
+def get_walk_forward_slices(
+    meta: dict,
+    start: str,
+    end: str,
+    train_span_days: int,
+    test_span_days: int,
+    vendor: str = "yfinance",
+) -> list[tuple[pd.DataFrame, pd.Series]]:
+    """Return expanding train/rolling test slices of context and true returns."""
+
+    symbols = meta.get("series_list", [])
+    df = fetch_prices(symbols, start, end, vendor=vendor, interval="1d")
+    df = repair_calendar(df)
+    df = (
+        df.reset_index()
+        .pivot(index="date", columns="symbol")
+        .ffill()
+    )
+    df.columns = [f"{sym}_{col}" for col, sym in df.columns]
+
+    logret = df[f"{meta['target_ticker']}_close"].pct_change().apply(lambda x: 0.0 if pd.isna(x) else x)
+    df["_logret"] = logret
+
+    dates = df.index
+    slices: list[tuple[pd.DataFrame, pd.Series]] = []
+    start_idx = 0
+    while True:
+        train_end = start_idx + train_span_days
+        test_end = train_end + test_span_days
+        if test_end > len(df):
+            break
+        ctx_df = df.iloc[train_end - meta["ctx_len"]:train_end]
+        true_returns = df["_logret"].iloc[train_end:test_end]
+        slices.append((ctx_df, true_returns))
+        start_idx += test_span_days
+    return slices

--- a/src/backtest/metrics.py
+++ b/src/backtest/metrics.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def smape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return np.mean(2 * np.abs(y_pred - y_true) / (np.abs(y_true) + np.abs(y_pred)))
+
+
+def mae(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return np.mean(np.abs(y_pred - y_true))
+
+
+def rmse(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.sqrt(np.mean((y_pred - y_true) ** 2)))
+
+
+def directional_accuracy(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.mean(np.sign(y_true) == np.sign(y_pred)))
+
+
+def trading_stats(pl_series: pd.Series, initial_cash: float = 1.0) -> dict:
+    try:
+        import vectorbt as vbt  # type: ignore
+
+        returns = pl_series / initial_cash
+        pf = vbt.Portfolio.from_returns(returns)
+        return {
+            "cum_return": float(pf.total_return()),
+            "sharpe": float(pf.sharpe_ratio()),
+            "max_dd": float(pf.max_drawdown()),
+        }
+    except Exception:
+        # Fallback simple metrics
+        equity = (pl_series / initial_cash + 1).cumprod()
+        cum_return = equity.iloc[-1] - 1
+        ret = pl_series / initial_cash
+        sharpe = ret.mean() / (ret.std() + 1e-9) * np.sqrt(len(ret))
+        peak = equity.cummax()
+        dd = (equity - peak) / peak
+        max_dd = dd.min()
+        return {"cum_return": float(cum_return), "sharpe": float(sharpe), "max_dd": float(max_dd)}
+
+
+def compute_all_metrics(df_res: pd.DataFrame) -> dict:
+    y_true = df_res["pl"].values
+    y_pred = df_res["est_ret"].values
+    out = {
+        "smape": smape(y_true, y_pred),
+        "mae": mae(y_true, y_pred),
+        "rmse": rmse(y_true, y_pred),
+        "directional_accuracy": directional_accuracy(y_true, y_pred),
+    }
+    out.update(trading_stats(df_res["pl"]))
+    return out

--- a/src/backtest/report.py
+++ b/src/backtest/report.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import mlflow
+import pandas as pd
+
+
+def log_to_mlflow(metrics: dict, df_res: pd.DataFrame, cfg) -> None:
+    mlflow.log_metrics(metrics)
+    tmp_path = "results.pkl"
+    df_res.to_pickle(tmp_path)
+    mlflow.log_artifact(tmp_path)

--- a/src/backtest/strategy.py
+++ b/src/backtest/strategy.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseStrategy(ABC):
+    @abstractmethod
+    def generate(self, est_ret: float) -> int:
+        """Return position based on estimated return."""
+        raise NotImplementedError
+
+
+class ThresholdLongShort(BaseStrategy):
+    def __init__(self, long: float = 0.002, short: float = -0.002):
+        self.long = long
+        self.short = short
+
+    def generate(self, est_ret: float) -> int:
+        if est_ret > self.long:
+            return 1
+        if est_ret < self.short:
+            return -1
+        return 0

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from src.backtest.strategy import ThresholdLongShort
+from src.backtest.engine import BacktestEngine
+from src.serving.predictor import Predictor
+
+
+class DummyPredictor(Predictor):
+    def _load_model(self, uri: str, ticker: str):
+        meta = {
+            "scaler_path": "",
+            "ctx_len": 2,
+            "series_list": ["a", "b"],
+            "target_ticker": "a",
+        }
+
+        class DummyModel:
+            def __call__(self, x):
+                return np.array([[0.01]], dtype=np.float32)
+
+        return DummyModel(), meta
+
+    def predict_next(self, df_ctx: pd.DataFrame) -> float:  # type: ignore[override]
+        return 0.01
+
+
+def test_threshold_generate():
+    strat = ThresholdLongShort(long=0.005, short=-0.005)
+    assert strat.generate(0.01) == 1
+    assert strat.generate(-0.01) == -1
+    assert strat.generate(0.0) == 0
+
+
+def test_engine_walk_forward():
+    pred = DummyPredictor("uri", "TST")
+    strat = ThresholdLongShort()
+    engine = BacktestEngine(pred, strat)
+    ctx = pd.DataFrame([[1, 2], [1, 2]], columns=["a", "b"])
+    true_ret = pd.Series([0.02])
+    est, sig, pl = engine.run_slice(ctx, true_ret)
+    assert est == 0.01
+    assert sig in (-1, 0, 1)
+    assert isinstance(pl, float)


### PR DESCRIPTION
## Summary
- implement backtesting skeleton based on blueprint
- include loader, engine, strategy, metrics, report, and CLI
- add Hydra config for backtests
- add unit tests for strategy and engine

## Testing
- `pip install pandas` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865370bcec8832ea25d6cb2b916ff87