### PR TITLE
Add MLflow docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  mlflow:
+    image: mlflow/mlflow
+    container_name: mlflow.internal
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./mlruns:/mlflow/mlruns
+    command: >
+      mlflow server --host 0.0.0.0 --port 5000 \
+        --backend-store-uri sqlite:///mlflow/mlflow.db \
+        --default-artifact-root /mlflow/mlruns
+


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with an `mlflow` service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865bc12c398832e9567bded1a795271